### PR TITLE
csv_format: Use pathlib.Path for output_dir

### DIFF
--- a/firststreet/api/csv_format.py
+++ b/firststreet/api/csv_format.py
@@ -5,6 +5,7 @@
 import datetime
 import logging
 import os
+import pathlib
 import shapely.geometry
 
 # External Imports
@@ -33,7 +34,8 @@ def to_csv(data, product, product_subtype, location_type=None, output_dir=None):
         file_name = "_".join([date, product, product_subtype]) + ".csv"
 
     if not output_dir:
-        output_dir = os.getcwd() + "/output_data"
+        output_dir = pathlib.Path(os.getcwd()) / "output_data"
+    output_dir = pathlib.Path(output_dir)
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -194,8 +196,8 @@ def to_csv(data, product, product_subtype, location_type=None, output_dir=None):
         df = df.drop(columns=['error'])
 
     df = df.fillna(pd.NA).astype(str)
-    df.to_csv(output_dir + '/' + file_name, index=False)
-    logging.info("CSV generated to '{}'.".format(output_dir + '/' + file_name))
+    df.to_csv(output_dir / file_name, index=False)
+    logging.info("CSV generated to '{}'.".format(output_dir / file_name))
 
 
 def get_geom_center(geom):


### PR DESCRIPTION
Otherwise,
- the library raises an error if I pass in a pathlib.Path object into
  output_dir argument
  ` TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'`
- the library won't work on Windows, which uses '\' instead of '/' (not
  yet tested because I don't have an access to a Windows box).