### PR TITLE
format_aal_summary_property: Replace .apply(pd.Series) with more performant alternative

### DIFF
--- a/firststreet/api/csv_format.py
+++ b/firststreet/api/csv_format.py
@@ -1185,7 +1185,7 @@ def format_aal_summary_property(data):
             if pd.isnull(dl):
                 return pd.NA, pd.NA
             return dl['depth'], dl['data']
-        df['depth'], df['data'] = zip(*df['depth_loss'].apply(expand_dl))
+        df['depth'], df['damage'] = zip(*df['depth_loss'].apply(expand_dl))
         df.drop(['depth_loss'], axis=1)
     else:
         df['fsid'] = df['fsid'].apply(str)
@@ -1198,7 +1198,6 @@ def format_aal_summary_property(data):
         df['mid'] = pd.NA
         df['high'] = pd.NA
 
-    df.rename(columns={'data': 'damage'}, inplace=True)
     df['fsid'] = df['fsid'].apply(str)
     df['year'] = df['year'].astype('Int64').apply(str)
     df['low'] = df['low'].astype('Int64').apply(str)

--- a/firststreet/api/csv_format.py
+++ b/firststreet/api/csv_format.py
@@ -1174,16 +1174,19 @@ def format_aal_summary_property(data):
     df = df.explode('depth_loss')
 
     if not df[['annual_loss', 'depth_loss']].isna().values.all():
-        df = pd.concat([df.drop(['annual_loss'], axis=1), df['annual_loss'].apply(pd.Series)], axis=1)
-        if 'data' in df.columns:
-            df = pd.concat([df.drop(['data'], axis=1), df['data'].apply(pd.Series)], axis=1)
-        else:
-            df['year'] = pd.NA
-            df['low'] = pd.NA
-            df['mid'] = pd.NA
-            df['high'] = pd.NA
+        def expand_al(al):
+            if pd.isnull(al):
+                return pd.NA, pd.NA, pd.NA, pd.NA
+            return al['year'], al['data']['low'], al['data']['mid'], al['data']['high']
+        df['year'], df['low'], df['mid'], df['high'] = zip(*df['annual_loss'].apply(expand_al))
+        df.drop(['annual_loss'], axis=1)
 
-        df = pd.concat([df.drop(['depth_loss'], axis=1), df['depth_loss'].apply(pd.Series)], axis=1)
+        def expand_dl(dl):
+            if pd.isnull(dl):
+                return pd.NA, pd.NA
+            return dl['depth'], dl['data']
+        df['depth'], df['data'] = zip(*df['depth_loss'].apply(expand_dl))
+        df.drop(['depth_loss'], axis=1)
     else:
         df['fsid'] = df['fsid'].apply(str)
         df.drop(['annual_loss'], axis=1, inplace=True)


### PR DESCRIPTION
For details of the benchmark, see the answer https://stackoverflow.com/a/61039138.

I have observed that the most time consuming part of my bulk download of AAL data is in the conversion to CSV (1 min to download 5000 entries, 5 min to convert, in a Amazon AWS t2.micro instance). This refactor will speed up the process by 36x!